### PR TITLE
catalogue-service: Fix product ID type comparison in product retrieval endpoint

### DIFF
--- a/catalogue/app.py
+++ b/catalogue/app.py
@@ -45,7 +45,7 @@ def get_products():
 
 @app.route('/api/products/<int:product_id>', methods=['GET'])
 def get_product(product_id):
-    product = next((product for product in products if product['id'] == product_id), None)
+    product = next((product for product in products if product['id'] == str(product_id)), None)
     if product is not None:
         return jsonify(product)
     else:

--- a/catalogue/app.py.bak
+++ b/catalogue/app.py.bak
@@ -20,7 +20,7 @@ def get_products():
 
 @app.route('/api/products/<int:product_id>', methods=['GET'])
 def get_product(product_id):
-    product = next((product for product in products if product['id'] == product_id), None)
+    product = next((product for product in products if product['id'] == str(product_id)), None)
     if product is not None:
         return jsonify(product)
     else:

--- a/catalogue/test_app.py
+++ b/catalogue/test_app.py
@@ -35,5 +35,16 @@ class FlaskTest(unittest.TestCase):
         self.assertTrue(b'name' in response.data)
         self.assertTrue(b'image_url' in response.data)
 
+    # Test successful product retrieval by ID
+    def test_get_product_success(self):
+        logging.info("TEST-05: Testing successful product retrieval by ID...")
+        tester = app.test_client(self)
+        response = tester.get('/api/products/1', content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(b'name' in response.data)
+        self.assertTrue(b'description' in response.data)
+        self.assertTrue(b'image_url' in response.data)
+        self.assertTrue(b'id' in response.data)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Issue**: [Catalogue product by id route Comparing Int to String #13](https://github.com/craftista/craftista/issues/13)

**Summary**: 
This PR fixes a bug in the product retrieval endpoint in the catalogue microservice, where products could not be found by ID due to a type mismatch issue.

The [get_product_by_id](https://github.com/craftista/craftista/blob/ab88f0a02f66916031a8cc72b6133f04aa117b0f/catalogue/app.py#L46) endpoint was failing to retrieve products correctly because of a type comparison issue. The product_id values are stored as strings in the [products.json](https://github.com/craftista/craftista/blob/ab88f0a02f66916031a8cc72b6133f04aa117b0f/catalogue/products.json#L3) file, but the endpoint was attempting to match them against integer values, resulting in incorrect "product not found" errors.

**Solution**:
- Fixed type casting: Modified the product lookup logic to cast the integer ID parameter to a string before comparison with the stored product IDs
- Added test coverage: Implemented a comprehensive unit test to verify the product retrieval functionality works correctly and returns the expected response format with a 200 status code

**Changes**:
- Bug Fix (bug: Fix product ID type comparison): Updated the product lookup method to properly handle string-to-string comparison
- Test Addition (catalogue: test: Add test for product retrieval by ID): Added unit test to prevent regression and ensure the endpoint works as expected

**Testing**:
- New unit test verifies successful product retrieval by ID
- Test confirms proper response structure and HTTP status code
- Manual testing confirms the endpoint now works correctly

